### PR TITLE
Improve hero display on very wide resolutions

### DIFF
--- a/index.pug
+++ b/index.pug
@@ -15,9 +15,10 @@ html(lang="en")
 		link(rel="icon" type="image/png" href="/favicon-512.png" sizes="512x512")
 	body
 		header.hero.is-primary.is-bold: .hero-body
-			h1
-				.title YAML Multiline
-				.subtitle Find the right syntax for your YAML multiline strings
+			.container
+				h1
+					.title YAML Multiline
+					.subtitle Find the right syntax for your YAML multiline strings
 		main.section.container.content: include article.pug
 		script
 			include:uglify-js polyfills.js


### PR DESCRIPTION
This makes the site more readable on large screens like 32" monitors. Narrow screens are unaffected by this change.

**Before:**

![yaml_before](https://user-images.githubusercontent.com/180032/50666007-22dd4580-0fb3-11e9-994c-8196ef1001bf.png)

**After:**

![yaml_after](https://user-images.githubusercontent.com/180032/50666006-22dd4580-0fb3-11e9-8f46-e363ae98be0e.png)
