### PR TITLE
Enforce indentation boundaries in the demonstration

### DIFF
--- a/content/strings-demo.js
+++ b/content/strings-demo.js
@@ -17,7 +17,11 @@
 		}
 		indentIndication.innerHTML = form.elements.indent.value
 		var indents = document.getElementsByClassName('indent')
-		var indentation = '·'.repeat(form.elements.indent.value)
+		var indentCount = form.elements.indent.value
+		if (indentCount > 9 || indentCount <= 0) {
+			indentCount = 2
+		}
+		var indentation = '·'.repeat(indentCount)
 		for (var i = 0; i < indents.length; i++) {
 			indents[i].innerHTML = indentation
 		}


### PR DESCRIPTION
Currently, the indentation range allowed in the demo form element is 1-9. This is however not enforced though.
Added a small check to make sure the value is within the range, otherwise display the text with a default indentation of 2.﻿
